### PR TITLE
VHF: pass R828D reference clock (16 MHz) to TUNERINIT, not 0

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -330,7 +330,14 @@ fn main() {
         }) => {
             gpio |= GPIOPin::VHF_EN as u32;
 
-            rx888_send_command(&handle, FX3Command::TUNERINIT, 0)
+            // Pass the R828D's reference-clock frequency (16 MHz) here, not 0.
+            // The firmware forwards this value as the `freq` argument to
+            // `r820_initialize()`. Without a working reference the R828D PLL
+            // produces unpredictable LO frequencies and VHF reception drifts
+            // run-to-run with no decodable signal at the requested tune freq.
+            // Constant taken from ExtIO_sddc Core/radio/RX888R2Radio.cpp:3:
+            //     #define R828D_FREQ (16000000) // R820T reference frequency
+            rx888_send_command(&handle, FX3Command::TUNERINIT, 16_000_000)
                 .expect("Could not initialize tuner");
             rx888_send_command_u64(&handle, FX3Command::TUNERTUNE, frequency)
                 .expect("Could not tune tuner");

--- a/src/rx888.rs
+++ b/src/rx888.rs
@@ -5,6 +5,16 @@ use rusb::{
     Context, DeviceHandle,
 };
 
+/// Timeout for all vendor-class USB control transfers to the FX3.
+///
+/// 1 s was too tight: on first SuperSpeed enumeration the firmware can take
+/// > 1 s to ack STARTFX3 on at least one Intel host xHCI (Z270), causing a
+/// PollTimeout panic. 5 s is comfortably above the longest observed wait
+/// and harmless for the fast commands. Applied uniformly to all three send
+/// helpers — they all issue the same kind of vendor control transfer and
+/// are equally exposed to first-enumeration latency.
+const USB_CONTROL_TIMEOUT: Duration = Duration::from_secs(5);
+
 #[allow(dead_code)]
 pub enum FX3Command {
     // Start GPII engine and stream the data from ADC
@@ -134,15 +144,13 @@ pub fn rx888_send_command(
     cmd: FX3Command,
     data: u32,
 ) -> rusb::Result<usize> {
-    let timeout = Duration::from_secs(1);
-
     handle.write_control(
         LIBUSB_ENDPOINT_OUT | LIBUSB_REQUEST_TYPE_VENDOR,
         cmd as u8,
         0,
         0,
         &data.to_le_bytes(),
-        timeout,
+        USB_CONTROL_TIMEOUT,
     )
 }
 
@@ -151,15 +159,13 @@ pub fn rx888_send_command_u64(
     cmd: FX3Command,
     data: u64,
 ) -> rusb::Result<usize> {
-    let timeout = Duration::from_secs(1);
-
     handle.write_control(
         LIBUSB_ENDPOINT_OUT | LIBUSB_REQUEST_TYPE_VENDOR,
         cmd as u8,
         0,
         0,
         &data.to_le_bytes(),
-        timeout,
+        USB_CONTROL_TIMEOUT,
     )
 }
 
@@ -168,14 +174,12 @@ pub fn rx888_send_argument(
     cmd: ArgumentList,
     data: u16,
 ) -> rusb::Result<usize> {
-    let timeout = Duration::from_secs(1);
-
     handle.write_control(
         LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_ENDPOINT_OUT,
         FX3Command::SETARGFX3 as u8,
         data,
         cmd as u16,
         &[0],
-        timeout,
+        USB_CONTROL_TIMEOUT,
     )
 }


### PR DESCRIPTION
# PR: pass R828D reference clock (16 MHz) to `TUNERINIT` in VHF mode

## Summary

In VHF mode, `TUNERINIT` is being called with `data=0`. The firmware
treats that `data` value as the R828D's reference-clock frequency and
passes it straight into `r820_initialize(freq)`. With `0`, the R828D's
PLL initialises without a stable reference and ends up tuning to
unpredictable LO frequencies, so reception is effectively broken.

This matches the upstream ExtIO_sddc Windows code, which passes
`R828D_FREQ = 16_000_000`:

```cpp
// Core/radio/RX888R2Radio.cpp:78
uint32_t ref = R828D_FREQ;             // 16000000
return Fx3->Control(TUNERINIT, ref);   // Initialize Tuner
```

## Changes

- `src/main.rs`: pass `16_000_000` (R828D reference clock) to
  `TUNERINIT` in the `Commands::VHF` arm.
- `src/rx888.rs`: bump the control-transfer timeout from 1 s to 5 s.
  `STARTFX3` occasionally exceeded 1 s on first enumeration on a
  SuperSpeed link on my (Intel Z270) host. Not strictly required for
  the fix itself; happy to drop this hunk if you'd prefer it as a
  separate PR.

The first change is a one-liner; the second is also a one-liner.

## Before / after

Captured under identical conditions: same RX888 mk2, same UHF coax
source (UK PAL test signal at 591.2 MHz), same firmware
(`SDDC_FX3.img` from this tree), same gain settings.

**Before** — strongest narrow peak in three back-to-back captures at
the same `--frequency`:

```
capture 1: 2.0676 MHz   (transient)
capture 2: 6.2490 MHz   (clock spur, doesn't move with tune)
capture 3: 3.6385 MHz   (transient)
```

No reproducible carrier, no line-rate sideband comb detectable above
the noise floor. SMS-on vs SMS-off comparison shows essentially no
spectral difference, just receiver-internal RFI variation.

**After** the fix:

```
capture 1: 4.5613 MHz   (carrier at R828D_IF_CARRIER)
capture 2: 4.5613 MHz   (same)
capture 3: 4.5613 MHz   (same)
```

Carrier lands at the R828D's designed IF center every time. PAL
line-rate sidebands at exact 15.556 kHz spacing (the test source's
slightly-slow line rate) are visible from h=-10 to h=+10. SMS-on vs
SMS-off shows a **221× std ratio** and +92 dB difference on the vision
carrier — i.e. obvious-when-you-look-at-it, matching what the Windows
side has been doing all along.

End-to-end the Linux pipeline now produces a recognisable video frame
from the PAL test source.

## Test plan

- [x] Built clean (`cargo build --release`)
- [x] Smoke test (`--measure` mode) confirms 24 MSps stream
- [x] Capture and analyse with SMS on: vision carrier at 4.57 MHz IF,
      ~80 dB SNR, full line-rate sideband comb
- [x] Capture with SMS off (negative control): carrier disappears
      (~80 dB delta), std drops 221×
- [x] Reproduce across multiple back-to-back captures: carrier
      position stable
- [x] End-to-end demodulation produces a recognisable video frame

## Disclosure

This PR was prepared by Claude Code acting under my (@mattgodbolt)
guidance and supervision. We spent a fair chunk of time chasing dead
ends — USB enumeration speed, multiple firmware variants, R828D
analog-vs-digital mode, host-side gain ordering — before finding the
actual bug by diffing the Windows host-side init sequence against the
Rust one. The fix is small, the root cause is unambiguous, and the
end-to-end Linux PAL capture now matches the Windows result.

Thanks for `rx888_stream`. It's been a pleasure working with — the
shape of the Rust code made the bug findable once we knew where to
look.

— Matt
