### PR TITLE
VHF: tighten --vhf-lna to 0-28 (off-by-one vs firmware tables)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,12 @@ const FX3_VID: u16 = 0x04b4;
 const FX3_BOOTLOADER_PID: u16 = 0x00f3;
 const FX3_FIRMWARE_PID: u16 = 0x00f1;
 
+/// Maximum valid `--vhf-lna` index. The SDDC firmware's `lna_gains[]` and
+/// `mixer_gains[]` tables have `GAIN_STEPS = 29` entries indexed `0..=28`;
+/// passing 29 reads off the end (undefined behaviour in stock firmware
+/// which has no bounds check). Update here if `GAIN_STEPS` ever changes.
+const MAX_VHF_LNA_GAIN: u8 = 28;
+
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 enum GainMode {
     High,
@@ -105,8 +111,9 @@ enum Commands {
         #[arg(long, display_order = 100, default_value_t = 145000000)]
         frequency: u64,
 
-        /// Tuner LNA gain 0-29
-        #[arg(long, display_order = 100, default_value_t = 29, value_parser = value_parser!(u8).range(0..=29))]
+        /// Tuner LNA gain 0-28
+        #[arg(long, display_order = 100, default_value_t = MAX_VHF_LNA_GAIN,
+              value_parser = value_parser!(u8).range(0..=MAX_VHF_LNA_GAIN as i64))]
         vhf_lna: u8,
 
         /// Tuner VGA gain 0-15


### PR DESCRIPTION
# PR: tighten `--vhf-lna` to 0-28 (off-by-one against firmware tables)

## Summary

`--vhf-lna` was 0..=29 with default 29, but the firmware's `lna_gains[]`
and `mixer_gains[]` tables only have 29 entries indexed 0..=28. Stock
firmware has no bounds check in `set_all_gains()`, so passing 29 reads
off the end of both arrays.

This PR tightens the clap range to 0..=28 and changes the default to
28 — the highest legitimate index — preserving "default = max gain"
behaviour.

## Changes

- `src/main.rs`: `--vhf-lna` range 0..=29 → 0..=28, default 29 → 28,
  with a comment explaining why.

One-liner of behavioural change; few extra lines of explanatory
comment.

## Disclosure

Prepared by Claude Code acting under my (@mattgodbolt) guidance and
supervision. Companion to #15.
